### PR TITLE
Made Discord link point to #faq

### DIFF
--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -1,6 +1,6 @@
 const mod = Vars.mods.getMod("aeyama");
 const urlGithub = "https://github.com/FredyJabe/aeyama";
-const urlDiscord = "https://discord.gg/rNhkswkJst";
+const urlDiscord = "https://discord.gg/YVY9Y3uA85";
 const urlTrello = "https://github.com/users/FredyJabe/projects/2";
 var aeyamaNews = "";
 Http.get(Core.bundle.format("urlNews"), response => {


### PR DESCRIPTION
Instead of #general, point them to #faq so they don't miss it when joining